### PR TITLE
Added timeout for credentials manager to handle locked entry cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Until work has been done to automate dependencies installation on package instal
 
 Password management is handled via `keytar` (check it out [here](https://www.npmjs.com/package/keytar)). `keytar` is using system specific solutions in order to store your password in a secure way. This allows `git-assist` to reuse your saved password when working with _GitHub_ and not prompt you every time for it.
 
-**For _Linux_ users:** you may encounter some undesired behavior if you use `git-assist` without a preconfigured keyring to store your passwords. It seems like `keytar` is creating for you a default keyring with a set password if no default keyring was found on first run. This can lead users to not being able to unlock this keyring afterward and therefore freezes some applications or make `git-assist` unusable.
+**For _Linux_ users:** you may encounter some undesired behavior if you use `git-assist` without a preconfigured keyring to store your passwords. It seems like `keytar` is creating for you a default keyring with a set password if no default keyring was found on first run. This can lead users to not being able to unlock this keyring afterward and therefore freezes some applications.
 
 Below are details on how to handle/prevent this situation.
 
@@ -62,7 +62,7 @@ It is recommended to perform this step before working with `git-assist` if you d
 
 ### :question: How to fix a locked default keyring
 
-If you started using `git-assist` with no keyring configured it is possible that some of your apps may be frozen or `git-assist` just hangs in a process (fix coming soon).
+If you started using `git-assist` with no keyring configured it is possible that some of your apps may be frozen because the keyring would be locked (since you don't know the password to unlock it).
 
 1. go into `~/.local/share/keyrings` either via your console and via your file explorer
 2. delete the file containing `default` in its name and ending with `.keyring` (via terminal or file explorer)

--- a/src/utils/auth/auth.js
+++ b/src/utils/auth/auth.js
@@ -4,6 +4,7 @@ module.exports = {
   onAuth: async (url, auth) => {
     const username = await getUsername()
     let password = await pwdManager.getPwd(username)
+    console.log(password)
     if (!password) {
       password = await askPwd(username)
     }

--- a/src/utils/auth/pwd-manager.js
+++ b/src/utils/auth/pwd-manager.js
@@ -1,11 +1,9 @@
 module.exports = {
-  getPwd: async (user) => {
-    const keytar = require('keytar')
-    return await keytar.getPassword('git-assist', user)
+  getPwd: (user) => {
+    return timedWrapper(getPwdHandler, user)
   },
-  setPwd: async (user, password) => {
-    const keytar = require('keytar')
-    await keytar.setPassword('git-assist', user, password)
+  setPwd: (user, password) => {
+    return timedWrapper(setPwdHandler, user, password)
   },
   promptPwd: async () => {
     const inquirer = require('inquirer')
@@ -17,4 +15,23 @@ module.exports = {
       }
     ])
   }
+}
+
+function timedWrapper(task, ...args) {
+  return new Promise((resolve, reject) => {
+    task(...args).then(res => resolve(res))
+    setTimeout(() => {
+      reject('Timed out after 2 seconds! Your keyring may be locked, please check.')
+    }, 2000)
+  })
+}
+
+function getPwdHandler(user) {
+  const keytar = require('keytar')
+  return keytar.getPassword('git-assist', user)
+}
+
+function setPwdHandler (user, password) {
+  const keytar = require('keytar')
+  return keytar.setPassword('git-assist', user, password)
 }

--- a/src/utils/auth/pwd-manager.js
+++ b/src/utils/auth/pwd-manager.js
@@ -1,9 +1,9 @@
 module.exports = {
   getPwd: (user) => {
-    return timedWrapper(getPwdHandler, user)
+    return timedWrapper(getPwdHandler, user).catch(err => {throw new Error(err)})
   },
   setPwd: (user, password) => {
-    return timedWrapper(setPwdHandler, user, password)
+    return timedWrapper(setPwdHandler, user, password).catch(err => {throw new Error(err)})
   },
   promptPwd: async () => {
     const inquirer = require('inquirer')


### PR DESCRIPTION
Following #38: any calls to the keyring is now timed so that the program times out if we're not able to read/write information to keyring before a given time