### PR TITLE
Implemented auto-pull scheduling feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,15 +3,17 @@ process.on('SIGINT', function () {
   console.log('\n')
   clog.info('Gracefully shutting down (CTRL + C)...')
   clog.heading('END (USER REQUESTED)')
-  clog.on('finish', function(info) {
+  clog.end()
+  require(appRoot + '/src/utils/loggers/utils/get-file-transport.js')(clog)._dest.on('finish', function(info) {
     process.exit()
   })
 })
 
 process.on('beforeExit', async function () {
   clog.heading('END')
+  clog.end()
   await new Promise((resolve, reject) => {
-    clog.on('finish', function(info) {
+    require(appRoot + '/src/utils/loggers/utils/get-file-transport.js')(clog)._dest.on('finish', function(info) {
       resolve()
     })
     clog.on('error', function(err) {
@@ -70,7 +72,8 @@ async function processArgs(args) {
 main().catch(err => {
   clog.error(err.stack)
   clog.heading('END (UNEXPECTED)')
-  clog.on('finish', function(info) {
+  clog.end()
+  require(appRoot + '/src/utils/loggers/utils/get-file-transport.js')(clog)._dest.on('finish', function(info) {
     process.exit()
   })
 })

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // **** PROCESS EVENT LISTENERS ****
-process.on('SIGINT', function () {
+process.on('SIGINT', () => {
   console.log('\n')
   finishJob(
     {
@@ -14,7 +14,7 @@ process.on('SIGINT', function () {
   )
 })
 
-process.on('beforeExit', function () {
+process.on('beforeExit', () => {
   finishJob({ level: 'heading', content: 'END' })
 })
 
@@ -85,7 +85,7 @@ function finishJob(...msgs) {
     clog[msg.level](msg.content)
   }
   clog.end()
-  clog.transports.find(transport => transport.name === 'file')._dest.on('finish', function(info) {
+  clog.transports.find(transport => transport.name === 'file')._dest.on('finish', (info) => {
     process.exit()
   })
 }

--- a/index.js
+++ b/index.js
@@ -2,8 +2,22 @@
 process.on('SIGINT', function () {
   console.log('\n')
   clog.info('Gracefully shutting down (CTRL + C)...')
-  clog.heading('REQUESTED END')
-  process.exit()
+  clog.heading('END (USER REQUESTED)')
+  clog.on('finish', function(info) {
+    process.exit()
+  })
+})
+
+process.on('beforeExit', async function () {
+  clog.heading('END')
+  await new Promise((resolve, reject) => {
+    clog.on('finish', function(info) {
+      resolve()
+    })
+    clog.on('error', function(err) {
+      reject()
+    })
+  })
 })
 
 async function main() {
@@ -20,7 +34,6 @@ async function main() {
   clog.heading(`START ${getHeading(fctName, args)}`)
   await require(fct.handler)(args)
   require('./src/utils/version/check-version.js')()
-  clog.heading(`END ${getHeading(fctName, args)}`)
 }
 
 function getLogger(fctName) {
@@ -56,5 +69,8 @@ async function processArgs(args) {
 
 main().catch(err => {
   clog.error(err.stack)
-  clog.heading('UNEXPECTED END')
+  clog.heading('END (UNEXPECTED)')
+  clog.on('finish', function(info) {
+    process.exit()
+  })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "git-assist",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "git-assist",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-assist",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "node utility to help working with GitHub",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-assist",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "node utility to help working with GitHub",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,10 @@
   "homepage": "https://github.com/alexlemaire/git-assist#readme",
   "keywords": [
     "git",
-    "cli",
     "github",
+    "cli",
+    "cli-app",
+    "automation",
     "pull",
     "push",
     "clone",

--- a/src/functions/auto-pull/helpers/auto-pull.js
+++ b/src/functions/auto-pull/helpers/auto-pull.js
@@ -1,18 +1,19 @@
-module.exports = async (path, excludedDirs) => {
+module.exports = async (path, excludedRepos, excludedBranches) => {
   const pathMod = require('path')
-  const repos = require(appRoot + '/src/utils/fs/list-repo.js')(path).filter(repo => !excludedDirs.includes(repo))
+  const repos = require(appRoot + '/src/utils/fs/list-repo.js')(path).filter(repo => !excludedRepos.includes(repo))
   const wd = process.cwd()
   for (const repo of repos) {
     clog.info(`Pulling for ${repo}`)
     process.chdir(pathMod.join(path, repo))
-    await require(appRoot + '/src/functions/pull/helpers/git-process/pull.js')(await require(appRoot + '/src/utils/auth/get-protocol.js')(), await listBranches())
+    await require(appRoot + '/src/functions/pull/helpers/git-process/pull.js')(await require(appRoot + '/src/utils/auth/get-protocol.js')(), await listBranches(repo, excludedBranches))
   }
   process.chdir(wd)
 }
 
-async function listBranches() {
+async function listBranches(repo, excludedBranches) {
   const fs = require('fs')
   const git = require('isomorphic-git')
   const dir = '.'
-  return await git.listBranches({ fs, dir })
+  const branches = await git.listBranches({ fs, dir })
+  return branches.filter(branch => !excludedBranches[repo].includes(branch))
 }

--- a/src/functions/auto-pull/helpers/conf-check.js
+++ b/src/functions/auto-pull/helpers/conf-check.js
@@ -1,0 +1,60 @@
+const chalk = require('chalk')
+
+module.exports = async (config) => {
+  const { confirm } = await promptConfirm(config)
+  if (!confirm) {
+    clog.info('Aborting process...')
+    process.exit()
+  }
+}
+
+async function promptConfirm(config) {
+  const path = config.get('path')
+  if (path) {
+    const inquirer = require('inquirer')
+    printConfig(path, config.get('excludedRepos'), config.get('excludedBranches'))
+    return await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'confirm',
+        message: 'A configuration for auto-pull already exists (see above). Would you like to update it?'
+      }
+    ])
+  }
+  return { confirm: false }
+}
+
+function format(msg) {
+  return chalk.magenta(msg)
+}
+
+function subFormat(msg) {
+  return chalk.blue(msg)
+}
+
+function printConfig(path, excludedRepos, excludedBranches) {
+  const autoPullPrint = chalk.italic.cyan('auto-pull')
+  clog.info(`Printing existing ${autoPullPrint} configuration...`)
+  console.log(format('\n---------\n'))
+  console.log(format(`${autoPullPrint} is currently pulling from: ${subFormat(path)}`))
+  if (excludedRepos.length > 0) {
+    console.log(format(`\nThe following repositories are not being processed by ${autoPullPrint}:\n${getReposMsg(excludedRepos, path)}`))
+  }
+  const excludedBranchesEntries = Object.entries(excludedBranches)
+  if (excludedBranchesEntries.length > 0) {
+    console.log(format(`\nThe following branches are not being processed by ${autoPullPrint}:\n${getBranchesMsg(excludedBranchesEntries)}`))
+  }
+  console.log(format('\n---------\n'))
+}
+
+function getReposMsg(excludedRepos, path) {
+  const indent = '    '
+  return excludedRepos.map(dir => subFormat(`${indent}- ${path}/${dir}`)).join('\n')
+}
+
+function getBranchesMsg(excludedBranchesEntries) {
+  const indent = '    '
+  const printHeader = repo => `${indent}${indent}*** ${repo} ***`
+  const printBranchesList = branches => branches.map(branch => `${indent}- ${branch}`).join('\n')
+  return excludedBranchesEntries.map(entry => subFormat(`${printHeader(entry[0])}\n\n${printBranchesList(entry[1])}`)).join('\n')
+}

--- a/src/functions/auto-pull/helpers/conf-prompter.js
+++ b/src/functions/auto-pull/helpers/conf-prompter.js
@@ -18,13 +18,26 @@ module.exports = async (args, config) => {
 }
 
 async function promptConfirm(config) {
-  if (config.has('path')) {
+  const path = config.get('path')
+  if (path) {
     const inquirer = require('inquirer')
+    const chalk = require('chalk')
+    const autoPullPrint = chalk.italic.cyan('auto-pull')
+    const excludedDirs = config.get('excludedDirs')
+    const format = msg => chalk.magenta(msg)
+    const subFormat = msg => chalk.blue(msg)
+    clog.info(`Printing existing ${autoPullPrint} configuration...`)
+    console.log(format('\n---------\n'))
+    console.log(format(`${autoPullPrint} is currently pulling from: ${subFormat(path)}`))
+    if (excludedDirs.length > 0) {
+      console.log(format(`\nThe following repositories are not being processed by ${autoPullPrint}: ${excludedDirs.map(dir => subFormat(`\n    - ${path}/${dir}`))}`))
+    }
+    console.log(format('\n---------\n'))
     return await inquirer.prompt([
       {
         type: 'confirm',
         name: 'confirm',
-        message: 'A configuration for auto-pull already exists. Would you like to update it?'
+        message: 'A configuration for auto-pull already exists (see above). Would you like to update it?'
       }
     ])
   }

--- a/src/functions/auto-pull/helpers/conf-prompter.js
+++ b/src/functions/auto-pull/helpers/conf-prompter.js
@@ -3,13 +3,32 @@ const fs = require('fs')
 const pathMod = require('path')
 inquirer.registerPrompt('fuzzypath', require('inquirer-fuzzy-path'))
 
-module.exports = async (args) => {
+module.exports = async (args, config) => {
+  const { confirm } = await promptConfirm(config)
+  if (!confirm) {
+    clog.info('Aborting process...')
+    process.exit()
+  }
   const path = await getPath(process.cwd(), args[0] === '--list-hidden')
   const { excludedDirs } = await getExcludedDirs(path)
   return {
     path,
     excludedDirs
   }
+}
+
+async function promptConfirm(config) {
+  if (config.has('path')) {
+    const inquirer = require('inquirer')
+    return await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'confirm',
+        message: 'A configuration for auto-pull already exists. Would you like to update it?'
+      }
+    ])
+  }
+  return { confirm: false }
 }
 
 async function getPath(root, listHidden) {

--- a/src/functions/auto-pull/helpers/create-pm2-startup.js
+++ b/src/functions/auto-pull/helpers/create-pm2-startup.js
@@ -1,0 +1,35 @@
+module.exports = async (config) => {
+  if (process.version === config.get('node_version') && config.get('startup_ran')) {
+    clog.info('No need to create pm2 startup script for this machine.')
+    return
+  }
+  clog.info('Creating pm2 startup script for this machine...')
+  startup(config)
+  clog.success('pm2 startup script successfully created!')
+}
+
+function startup(config) {
+  const chalk = require('chalk')
+  console.log(`\n${chalk.cyan('---------------')}\n`)
+  console.log(`${chalk.cyan('All information displayed below are related to PM2...')}`)
+  console.log(`${chalk.italic.cyan('Running pm2 unstartup...')}\n`)
+  execPm2Cli('unstartup')
+  console.log(`\n${chalk.italic.cyan('Running pm2 startup...')}\n`)
+  execPm2Cli('startup')
+  console.log(`\n${chalk.cyan('---------------')}\n`)
+  config.set('node_version', process.version)
+  config.set('startup_ran', true)
+}
+
+function execPm2Cli(cmd) {
+  const childProc = require('child_process')
+  const pm2Call = childProc.spawnSync('node', [`${appRoot}/node_modules/pm2/bin/pm2`, cmd])
+  if (pm2Call.error) {
+    throw error
+  }
+  try {
+    childProc.execSync(pm2Call.stdout.toString().trim(), {stdio: 'inherit'})
+  } catch (err) {
+    throw err
+  }
+}

--- a/src/functions/auto-pull/helpers/create-pm2-startup.js
+++ b/src/functions/auto-pull/helpers/create-pm2-startup.js
@@ -1,11 +1,34 @@
+const childProc = require('child_process')
+
 module.exports = async (config) => {
   if (process.version === config.get('node_version') && config.get('startup_ran')) {
     clog.info('No need to create pm2 startup script for this machine.')
     return
   }
+  const { confirm } = await promptConfirm()
+  if (!confirm) {
+    clog.info('Aborting process...')
+    process.exit()
+  }
+  const pm2Version = require(appRoot + '/package.json').dependencies.pm2
+  if (pm2Version !== config.get('pm2_version')) {
+    childProc.spawnSync('node', [`${appRoot}/node_modules/pm2/bin/pm2`, 'update'])
+    config.set('pm2_version', pm2Version)
+  }
   clog.info('Creating pm2 startup script for this machine...')
   startup(config)
   clog.success('pm2 startup script successfully created!')
+}
+
+async function promptConfirm() {
+  const inquirer = require('inquirer')
+  return await inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'confirm',
+      message: 'About to unstartup/startup pm2 and potentially update the in-memory process. If you are already using pm2, you will need to restart all your processes and save them again. Are you sure you want to proceed?'
+    }
+  ])
 }
 
 function startup(config) {
@@ -13,16 +36,15 @@ function startup(config) {
   console.log(`\n${chalk.cyan('---------------')}\n`)
   console.log(`${chalk.cyan('All information displayed below are related to PM2...')}`)
   console.log(`${chalk.italic.cyan('Running pm2 unstartup...')}\n`)
-  execPm2Cli('unstartup')
+  pm2ManualCall('unstartup')
   console.log(`\n${chalk.italic.cyan('Running pm2 startup...')}\n`)
-  execPm2Cli('startup')
+  pm2ManualCall('startup')
   console.log(`\n${chalk.cyan('---------------')}\n`)
   config.set('node_version', process.version)
   config.set('startup_ran', true)
 }
 
-function execPm2Cli(cmd) {
-  const childProc = require('child_process')
+function pm2ManualCall(cmd) {
   const pm2Call = childProc.spawnSync('node', [`${appRoot}/node_modules/pm2/bin/pm2`, cmd])
   if (pm2Call.error) {
     throw error

--- a/src/functions/auto-pull/helpers/create-pm2-startup.js
+++ b/src/functions/auto-pull/helpers/create-pm2-startup.js
@@ -1,6 +1,8 @@
 const childProc = require('child_process')
 
 module.exports = async (config) => {
+  const localVer = require(appRoot + '/package.json').dependencies.pm2.replace('^', '')
+  checkGlobalVer(localVer)
   if (process.version === config.get('node_version') && config.get('startup_ran')) {
     clog.info('No need to create pm2 startup script for this machine.')
     return
@@ -10,10 +12,9 @@ module.exports = async (config) => {
     clog.info('Aborting process...')
     process.exit()
   }
-  const pm2Version = require(appRoot + '/package.json').dependencies.pm2
-  if (pm2Version !== config.get('pm2_version')) {
+  if (localVer !== config.get('pm2_version')) {
     childProc.spawnSync('node', [`${appRoot}/node_modules/pm2/bin/pm2`, 'update'])
-    config.set('pm2_version', pm2Version)
+    config.set('pm2_version', localVer)
   }
   clog.info('Creating pm2 startup script for this machine...')
   startup(config)
@@ -29,6 +30,14 @@ async function promptConfirm() {
       message: 'About to unstartup/startup pm2 and potentially update the in-memory process. If you are already using pm2, you will need to restart all your processes and save them again. Are you sure you want to proceed?'
     }
   ])
+}
+
+function checkGlobalVer(localVer) {
+  const chalk = require('chalk')
+  const globalVer = childProc.spawnSync('pm2', ['-v']).stdout.toString().trim()
+  if (globalVer.match(/(\d+)\.(\d+)\.(\d+)/) && globalVer !== localVer) {
+    clog.info(`${chalk.underline('WARNING')}: your globally installed ${chalk.italic.cyan('pm2')} version is ${globalVer}. The locally used version of ${chalk.italic.cyan('pm2')} is ${localVer}. You may want to update your globally installed ${chalk.italic.cyan('pm2')} version to avoid conflict of in-memory process versions...`)
+  }
 }
 
 function startup(config) {

--- a/src/functions/auto-pull/helpers/get-processes.js
+++ b/src/functions/auto-pull/helpers/get-processes.js
@@ -1,0 +1,7 @@
+module.exports = async () => {
+  const pm2 = require(appRoot + '/src/utils/pm2/pm2-utils.js')
+  let processes = await pm2.connect().then(res => pm2.list()).then(processList => processList.filter(process => process.name.includes('auto-pull')))
+  processes = processes.map(process => process.name)
+  await pm2.disconnect()
+  return processes
+}

--- a/src/functions/auto-pull/helpers/schedule-process.js
+++ b/src/functions/auto-pull/helpers/schedule-process.js
@@ -27,7 +27,7 @@ async function processAction(opts) {
       await addProcess(opts)
       break
     case 'edit':
-      clog.info(`Editing ${chalk.italic.blue(opts.name)} process...`)
+      clog.info(`Updating ${chalk.italic.blue(opts.name)} process...`)
       await editProcess(opts)
       break
     case 'delete':

--- a/src/functions/auto-pull/helpers/schedule-process.js
+++ b/src/functions/auto-pull/helpers/schedule-process.js
@@ -8,9 +8,6 @@ module.exports = async (opts) => {
   if (!opts.scheduled) {
     return
   }
-  console.log('\n')
-  clog.info(`${chalk.underline('BEWARE')}: this feature is kind of experimental. If you encounter any bug please report it @ ${chalk.italic.cyan(require(appRoot + '/package.json').bugs.url)}`)
-  console.log('\n')
   clog.info(`Scheduling ${chalk.italic.blue('auto-pull')}...`)
   await processAction(opts)
   clog.success(`${chalk.italic.blue('auto-pull')} scheduling successfully updated!`)

--- a/src/functions/auto-pull/helpers/schedule-process.js
+++ b/src/functions/auto-pull/helpers/schedule-process.js
@@ -1,4 +1,49 @@
 module.exports = (opts) => {
   const chalk = require('chalk')
-  clog.info(`Configuration of auto-pull on startup and scheduled is not supported yet. You can auto-pull manually by calling ${chalk.blue.italic('git-assist auto-pull')}`)
+  if (process.platform === 'win32') {
+    throw new Error(`Apologies, scheduling ${chalk.italic.blue('auto-pull')} is currently not supported on Windows...`)
+  }
+  if (opts.scheduled) {
+    clog.info(`Scheduling ${chalk.italic.blue('auto-pull')}...`)
+    daemonize(opts)
+    clog.success(`${chalk.italic.blue('auto-pull')} scheduled!`)
+  }
+}
+
+function daemonize (opts) {
+  const pm2 = require('pm2')
+  const startConf = {
+    name: 'scheduled-auto-pull',
+    script: `${appRoot}/index.js'`,
+    args: 'auto-pull',
+    cron_restart: opts.cron,
+    max_memory_restart : '100M'
+  }
+  pm2.connect(async function(err) {
+    await errorHandler(err)
+    pm2.start(startConf, async function(err, apps) {
+      await errorHandler(err)
+      pm2.startup(process.platform === 'darwin' ? 'darwin' : 'systemd', async function(err, result) {
+        await errorHandler(err)
+        pm2.disconnect()
+      })
+    })
+  })
+}
+
+async function errorHandler(err) {
+  if (err) {
+    clog.error(`There was an error with PM2:\n${err[0]}`)
+    clog.heading('END (UNEXPECTED)')
+    clog.end()
+    await new Promise((resolve, reject) => {
+      require(appRoot + '/src/utils/loggers/utils/get-file-transport.js')(clog)._dest.on('finish', function(info) {
+        resolve()
+      })
+      clog.on('error', function(error) {
+        reject()
+      })
+    })
+    process.exit()
+  }
 }

--- a/src/functions/auto-pull/helpers/schedule-process.js
+++ b/src/functions/auto-pull/helpers/schedule-process.js
@@ -5,6 +5,7 @@ module.exports = async (opts) => {
     throw new Error(`Apologies, scheduling ${chalk.italic.blue('auto-pull')} is currently not supported on Windows...`)
   }
   if (opts.scheduled) {
+    clog.info('WARNING: this feature is kind of experimental. It may not work on some OS or on your machine. Feel free to file any bugs you encounter! (I did not have many machines to try this on and since PM2 is already setup on mines I am not sure how it will work on a machine without prior configuration...)')
     clog.info(`Scheduling ${chalk.italic.blue('auto-pull')}...`)
     await daemonize(opts)
     clog.success(`${chalk.italic.blue('auto-pull')} scheduled!`)

--- a/src/functions/auto-pull/helpers/schedule-process.js
+++ b/src/functions/auto-pull/helpers/schedule-process.js
@@ -8,16 +8,15 @@ module.exports = async (opts) => {
   if (!opts.scheduled) {
     return
   }
-  clog.info('WARNING: this feature is kind of experimental. It may not work on some OS or on your machine. Feel free to file any bugs you encounter! (I did not have many machines to try this on and since PM2 is already setup on mines I am not sure how it will work on a machine without prior configuration...)')
+  console.log('\n')
+  clog.info(`${chalk.underline('BEWARE')}: this feature is kind of experimental. If you encounter any bug please report it @ ${chalk.italic.cyan(require(appRoot + '/package.json').bugs.url)}`)
+  console.log('\n')
   clog.info(`Scheduling ${chalk.italic.blue('auto-pull')}...`)
   await processAction(opts)
   clog.success(`${chalk.italic.blue('auto-pull')} scheduling successfully updated!`)
 }
 
 async function processAction(opts) {
-  if (process.getuid() !== 0) {
-    throw new Error(`You must run this command with elevated rights... This command is working with ${chalk.italic.cyan('pm2')} to setup ${chalk.italic.cyan('auto-pull')} so that it restarts when your machine restarts.\nPlease run ${chalk.italic.blue('sudo git-assist auto-pull [-c, --config]')} instead.`)
-  }
   startConf = {
     script: `${appRoot}/index.js`,
     args: 'auto-pull',
@@ -77,8 +76,7 @@ async function pm2Update(...commands) {
   for (const command of commands) {
     await pm2[command.method](...command.params).catch(pm2ErrorHandler)
   }
-  await pm2.startup(null, {})
-  .then(res => pm2.dump())
+  await pm2.dump()
   .then(res => pm2.disconnect())
   .catch(pm2ErrorHandler)
 }

--- a/src/functions/auto-pull/helpers/schedule-process.js
+++ b/src/functions/auto-pull/helpers/schedule-process.js
@@ -69,13 +69,13 @@ async function editProcess(opts) {
 
 async function pm2Update(...commands) {
   const pm2 = require(appRoot + '/src/utils/pm2/pm2-utils.js')
+  const pm2Cli = require(appRoot + '/src/utils/pm2/pm2-cli.js')
   await pm2.connect().catch(pm2ErrorHandler)
   for (const command of commands) {
     await pm2[command.method](...command.params).catch(pm2ErrorHandler)
   }
-  await pm2.dump()
-  .then(res => pm2.disconnect())
-  .catch(pm2ErrorHandler)
+  pm2Cli(['save', '--force'])
+  await pm2.disconnect().catch(pm2ErrorHandler)
 }
 
 function pm2ErrorHandler(err) {

--- a/src/functions/auto-pull/helpers/schedule-process.js
+++ b/src/functions/auto-pull/helpers/schedule-process.js
@@ -1,49 +1,90 @@
 const chalk = require('chalk')
+let startConf
 
 module.exports = async (opts) => {
   if (process.platform === 'win32') {
     throw new Error(`Apologies, scheduling ${chalk.italic.blue('auto-pull')} is currently not supported on Windows...`)
   }
-  if (opts.scheduled) {
-    clog.info('WARNING: this feature is kind of experimental. It may not work on some OS or on your machine. Feel free to file any bugs you encounter! (I did not have many machines to try this on and since PM2 is already setup on mines I am not sure how it will work on a machine without prior configuration...)')
-    clog.info(`Scheduling ${chalk.italic.blue('auto-pull')}...`)
-    await daemonize(opts)
-    clog.success(`${chalk.italic.blue('auto-pull')} scheduled!`)
+  if (!opts.scheduled) {
+    return
   }
+  clog.info('WARNING: this feature is kind of experimental. It may not work on some OS or on your machine. Feel free to file any bugs you encounter! (I did not have many machines to try this on and since PM2 is already setup on mines I am not sure how it will work on a machine without prior configuration...)')
+  clog.info(`Scheduling ${chalk.italic.blue('auto-pull')}...`)
+  await processAction(opts)
+  clog.success(`${chalk.italic.blue('auto-pull')} scheduling successfully updated!`)
 }
 
-function daemonize (opts) {
+async function processAction(opts) {
   if (process.getuid() !== 0) {
     throw new Error(`You must run this command with elevated rights... This command is working with ${chalk.italic.cyan('pm2')} to setup ${chalk.italic.cyan('auto-pull')} so that it restarts when your machine restarts.\nPlease run ${chalk.italic.blue('sudo git-assist auto-pull [-c, --config]')} instead.`)
   }
-  const startConf = {
-    name: 'scheduled-auto-pull',
+  startConf = {
     script: `${appRoot}/index.js`,
     args: 'auto-pull',
     cron_restart: opts.cron,
     max_memory_restart : '100M',
     autorestart: false
   }
-  promisifyPm2('connect')
-  .then(res => promisifyPm2('start', startConf))
-  .then(res => promisifyPm2('startup', null, {}))
-  .then(res => promisifyPm2('dump'))
-  .then(res => promisifyPm2('disconnect'))
+  switch (opts.action) {
+    case 'add':
+      clog.info(`Adding ${chalk.italic.blue(opts.type)} scheduled run for ${chalk.italic.cyan('auto-pull')}...`)
+      await addProcess(opts)
+      break
+    case 'edit':
+      clog.info(`Editing ${chalk.italic.blue(opts.name)} process...`)
+      await editProcess(opts)
+      break
+    case 'delete':
+      clog.info(`Deleting ${chalk.italic.blue(opts.name)} process...`)
+      await deleteProcess(opts)
+      break
+  }
+}
+
+async function addProcess(opts) {
+  startConf.name = `${opts.type}-auto-pull`
+  await pm2Update([
+    {
+      method: 'start',
+      params: [startConf]
+    }
+  ])
+}
+
+async function deleteProcess(opts) {
+  await pm2Update([
+    {
+      method: 'delete',
+      params: [opts.name]
+    }
+  ])
+}
+
+async function editProcess(opts) {
+  startConf.name = opts.name
+  await pm2Update([
+    {
+      method: 'delete',
+      params: [opts.name]
+    },
+    {
+      method: 'start',
+      params: [startConf]
+    }
+  ])
+}
+
+async function pm2Update(commands) {
+  const pm2 = require(appRoot + '/src/utils/pm2/pm2-utils.js')
+  await pm2.connect()
+  for (const command of commands) {
+    await pm2[command.method](...command.params)
+  }
+  await pm2.startup(null, {})
+  .then(res => pm2.dump())
+  .then(res => pm2.disconnect())
   .catch(err => {
     clog.error('There was an error with PM2...')
     throw new Error(err)
-  })
-}
-
-function promisifyPm2(method, ...params) {
-  const pm2 = require('pm2')
-  return new Promise((resolve, reject) => {
-    pm2[method](...params, function(err, data) {
-      if (err) {
-        reject(err)
-      } else {
-        resolve(data)
-      }
-    })
   })
 }

--- a/src/functions/auto-pull/helpers/schedule-prompter.js
+++ b/src/functions/auto-pull/helpers/schedule-prompter.js
@@ -1,16 +1,62 @@
+const inquirer = require('inquirer')
+const chalk = require('chalk')
+
 module.exports = async () => {
-  const inquirer = require('inquirer')
+  const processes = await require('./get-processes.js')()
+  const { action } = await getAction(processes)
+  let res = {
+    scheduled: true
+  }
+  switch (action) {
+    case 'nothing':
+      res.scheduled = false
+      break
+    case 'add':
+      const addAnswer = await addActionPrompt(processes)
+      if (!addAnswer.type) {
+        clog.info(`There are no scheduled ${chalk.italic.cyan('auto-pull')} runs you can add for this machine.`)
+        res.scheduled = false
+      }
+      res = {...res, action, ...addAnswer}
+      break
+    case 'edit':
+    case 'delete':
+      const editAnswer = await editActionPrompt(processes, action)
+      if (!editAnswer.name) {
+        clog.info(`There are no scheduled ${chalk.italic.cyan('auto-pull')} runs you can ${action} for this machine.`)
+        res.scheduled = false
+      }
+      res = {...res, action, ...editAnswer}
+      break
+  }
+  return res
+}
+
+async function getAction(processes) {
+  const subChoices = processes.length > 0 ? ['edit', 'delete'] : []
   const questions = [
     {
-      type: 'confirm',
-      name: 'scheduled',
-      message: 'Would you like to schedule auto-pull for automatic runs?'
-    },
+      type: 'rawlist',
+      name: 'action',
+      message: 'You can also schedule auto-pull to run automatically. What would you like to do?',
+      choices: ['add', ...subChoices, 'nothing']
+    }
+  ]
+  return await inquirer.prompt(questions)
+}
+
+async function addActionPrompt(processes) {
+  const processTypes = processes.map(process => process.replace(/-auto-pull/g, ''))
+  const choices = ['startup', 'cron'].filter(choice => !processTypes.includes(choice))
+  const questions = [
     {
       type: 'rawlist',
       name: 'type',
-      message: 'How would you like to schedule auto-pull?',
-      choices: ['startup', 'cron']
+      message: 'What kind of scheduled run would you like to add?',
+      choices,
+      when: function (answer) {
+        return choices.length > 0
+      }
     },
     {
       type: 'input',
@@ -19,6 +65,37 @@ module.exports = async () => {
       default: '0 0 * * 1',
       when: function (answer) {
         return answer.type === 'cron'
+      }
+    }
+  ]
+  return await inquirer.prompt(questions)
+}
+
+async function editActionPrompt(processes, action) {
+  let choices = processes
+  if (action === 'edit') {
+    choices = choices.filter(choice => choice.replace(/-auto-pull/g, '') !== 'startup')
+  }
+  const questions = [
+    {
+      type: 'rawlist',
+      name: 'name',
+      message: `Select a process you would like to ${action}?`,
+      choices,
+      when: function (answer) {
+        return choices.length > 0
+      }
+    },
+    {
+      type: 'input',
+      name: 'cron',
+      message: 'Please enter a new cron pattern for your auto-pull scheduled runs:',
+      default: '0 0 * * 1',
+      when: function (answer) {
+        if (!answer.name) {
+          return false
+        }
+        return answer.name.startsWith('cron') && action === 'edit'
       }
     }
   ]

--- a/src/functions/auto-pull/helpers/schedule-prompter.js
+++ b/src/functions/auto-pull/helpers/schedule-prompter.js
@@ -1,12 +1,16 @@
 const inquirer = require('inquirer')
 const chalk = require('chalk')
 
-module.exports = async () => {
-  const processes = await require('./get-processes.js')()
-  const { action } = await getAction(processes)
-  let res = {
-    scheduled: true
+module.exports = async (config) => {
+  const answer = await processAction(await require('./get-processes.js')(), { scheduled: true })
+  if (answer.scheduled) {
+    await require('./create-pm2-startup.js')(config)
   }
+  return answer
+}
+
+async function processAction(processes, res) {
+  const { action } = await getAction(processes)
   switch (action) {
     case 'nothing':
       res.scheduled = false

--- a/src/functions/auto-pull/helpers/schedule-prompter.js
+++ b/src/functions/auto-pull/helpers/schedule-prompter.js
@@ -3,8 +3,23 @@ module.exports = async () => {
   const questions = [
     {
       type: 'confirm',
-      name: 'startup',
-      message: 'Would you like to auto-pull automatically on machine startup?'
+      name: 'scheduled',
+      message: 'Would you like to schedule auto-pull for automatic runs?'
+    },
+    {
+      type: 'rawlist',
+      name: 'type',
+      message: 'How would you like to schedule auto-pull?',
+      choices: ['startup', 'cron']
+    },
+    {
+      type: 'input',
+      name: 'cron',
+      message: 'Please enter a cron pattern to schedule your auto-pull runs:',
+      default: '0 0 * * 1',
+      when: function (answer) {
+        return answer.type === 'cron'
+      }
     }
   ]
   return await inquirer.prompt(questions)

--- a/src/functions/auto-pull/helpers/schedule-prompter.js
+++ b/src/functions/auto-pull/helpers/schedule-prompter.js
@@ -72,10 +72,7 @@ async function addActionPrompt(processes) {
 }
 
 async function editActionPrompt(processes, action) {
-  let choices = processes
-  if (action === 'edit') {
-    choices = choices.filter(choice => choice.replace(/-auto-pull/g, '') !== 'startup')
-  }
+  const choices = action !== 'edit' ? processes : processes.filter(process => process !== 'startup-auto-pull')
   const questions = [
     {
       type: 'rawlist',

--- a/src/functions/auto-pull/helpers/schedule-prompter.js
+++ b/src/functions/auto-pull/helpers/schedule-prompter.js
@@ -4,6 +4,9 @@ const chalk = require('chalk')
 module.exports = async (config) => {
   const answer = await processAction(await require('./get-processes.js')(), { scheduled: true })
   if (answer.scheduled) {
+    console.log('\n')
+    clog.info(`${chalk.underline('BEWARE')}: this feature is kind of experimental. If you encounter any bug please report it @ ${chalk.italic.cyan(require(appRoot + '/package.json').bugs.url)}`)
+    console.log('\n')
     await require('./create-pm2-startup.js')(config)
   }
   return answer

--- a/src/functions/auto-pull/index.js
+++ b/src/functions/auto-pull/index.js
@@ -1,11 +1,14 @@
 module.exports = async (args) => {
   const Conf = require('conf')
+  const chalk = require('chalk')
   const config = new Conf({
     configName: 'auto-pull',
     fileExtension: 'conf'
   })
   if (['-c', '--config'].includes(args[0])) {
+    clog.info(`Configurating ${chalk.italic.blue('auto-pull')}...`)
     config.store = await require('./helpers/conf-prompter.js')(args.splice(1))
+    clog.success(`${chalk.italic.blue('auto-pull')} successfully configured!`)
     require('./helpers/schedule-process.js')(await require('./helpers/schedule-prompter.js')())
   } else {
     const path = config.get('path')

--- a/src/functions/auto-pull/index.js
+++ b/src/functions/auto-pull/index.js
@@ -7,7 +7,7 @@ module.exports = async (args) => {
   })
   if (['-c', '--config'].includes(args[0])) {
     clog.info(`Configurating ${chalk.italic.blue('auto-pull')}...`)
-    config.store = {...config.store, ...await require('./helpers/conf-prompter.js')(args.splice(1))}
+    config.set(await require('./helpers/conf-prompter.js')(args.splice(1), config))
     clog.success(`${chalk.italic.blue('auto-pull')} successfully configured!`)
     await require('./helpers/schedule-process.js')(await require('./helpers/schedule-prompter.js')(config))
   } else {

--- a/src/functions/auto-pull/index.js
+++ b/src/functions/auto-pull/index.js
@@ -7,9 +7,9 @@ module.exports = async (args) => {
   })
   if (['-c', '--config'].includes(args[0])) {
     clog.info(`Configurating ${chalk.italic.blue('auto-pull')}...`)
-    config.store = await require('./helpers/conf-prompter.js')(args.splice(1))
+    config.store = {...config.store, ...await require('./helpers/conf-prompter.js')(args.splice(1))}
     clog.success(`${chalk.italic.blue('auto-pull')} successfully configured!`)
-    await require('./helpers/schedule-process.js')(await require('./helpers/schedule-prompter.js')())
+    await require('./helpers/schedule-process.js')(await require('./helpers/schedule-prompter.js')(config))
   } else {
     const path = config.get('path')
     if (!path) {

--- a/src/functions/auto-pull/index.js
+++ b/src/functions/auto-pull/index.js
@@ -9,7 +9,7 @@ module.exports = async (args) => {
     clog.info(`Configurating ${chalk.italic.blue('auto-pull')}...`)
     config.store = await require('./helpers/conf-prompter.js')(args.splice(1))
     clog.success(`${chalk.italic.blue('auto-pull')} successfully configured!`)
-    require('./helpers/schedule-process.js')(await require('./helpers/schedule-prompter.js')())
+    await require('./helpers/schedule-process.js')(await require('./helpers/schedule-prompter.js')())
   } else {
     const path = config.get('path')
     if (!path) {

--- a/src/functions/auto-pull/index.js
+++ b/src/functions/auto-pull/index.js
@@ -7,7 +7,8 @@ module.exports = async (args) => {
   })
   if (['-c', '--config'].includes(args[0])) {
     clog.info(`Configurating ${chalk.italic.blue('auto-pull')}...`)
-    config.set(await require('./helpers/conf-prompter.js')(args.splice(1), config))
+    await require('./helpers/conf-check.js')(config)
+    config.set(await require('./helpers/conf-prompter.js')(args.splice(1)))
     clog.success(`${chalk.italic.blue('auto-pull')} successfully configured!`)
     await require('./helpers/schedule-process.js')(await require('./helpers/schedule-prompter.js')(config))
   } else {
@@ -15,6 +16,6 @@ module.exports = async (args) => {
     if (!path) {
       throw new Error('No path defined in your auto-pull configuration. Please run git-assist auto-pull [-c, --config] in order to configurate your auto-pull utility.')
     }
-    await require('./helpers/auto-pull.js')(path, config.get('excludedDirs'))
+    await require('./helpers/auto-pull.js')(path, config.get('excludedRepos'), config.get('excludedBranches'))
   }
 }

--- a/src/utils/loggers/utils/get-file-transport.js
+++ b/src/utils/loggers/utils/get-file-transport.js
@@ -1,3 +1,0 @@
-module.exports = (logger) => {
-  return logger.transports.find(transport => transport.name === 'file')
-}

--- a/src/utils/loggers/utils/get-file-transport.js
+++ b/src/utils/loggers/utils/get-file-transport.js
@@ -1,0 +1,3 @@
+module.exports = (logger) => {
+  return logger.transports.find(transport => transport.name === 'file')
+}

--- a/src/utils/pm2/pm2-cli.js
+++ b/src/utils/pm2/pm2-cli.js
@@ -1,0 +1,9 @@
+module.exports = (cmds = [], catchError = true) => {
+  const spawnSync = require('child_process').spawnSync
+  const pm2Call = spawnSync('node', [`${appRoot}/node_modules/pm2/bin/pm2`, ...cmds])
+  if (pm2Call.error && catchError) {
+    clog.error('There was an error with PM2...')
+    throw error
+  }
+  return pm2Call
+}

--- a/src/utils/pm2/pm2-utils.js
+++ b/src/utils/pm2/pm2-utils.js
@@ -19,4 +19,4 @@ function buildExport(methods) {
   return exp
 }
 
-module.exports = buildExport(['connect', 'start', 'stop', 'delete', 'startup', 'dump', 'list', 'disconnect'])
+module.exports = buildExport(['connect', 'start', 'stop', 'delete', 'dump', 'list', 'disconnect'])

--- a/src/utils/pm2/pm2-utils.js
+++ b/src/utils/pm2/pm2-utils.js
@@ -1,0 +1,22 @@
+function promisifyPm2(method, ...params) {
+  const pm2 = require('pm2')
+  return new Promise((resolve, reject) => {
+    pm2[method](...params, function(err, data) {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(data)
+      }
+    })
+  })
+}
+
+function buildExport(methods) {
+  let exp = {}
+  methods.forEach(method => {
+    exp[method] = (...params) => promisifyPm2(method, ...params)
+  })
+  return exp
+}
+
+module.exports = buildExport(['connect', 'start', 'stop', 'delete', 'startup', 'dump', 'list', 'disconnect'])

--- a/src/utils/version/check-version.js
+++ b/src/utils/version/check-version.js
@@ -2,7 +2,7 @@ module.exports = () => {
   const chalk = require('chalk')
   const publishedVer = getPublishedVer()
   const currentVer = getCurrentVer()
-  if (currentVer !== publishedVer && !publishedVer) {
+  if (currentVer !== publishedVer && publishedVer.length > 0) {
     clog.info(`Your installed ${chalk.italic('git-assist')} version is outdated. Latest version is ${chalk.bold(publishedVer)}. Please update via ${chalk.cyan.italic('npm i -g git-assist')}`)
   }
 }


### PR DESCRIPTION
Multiple new features are included in this PR:

- `auto-pull` scheduling feature. User can now setup `auto-pull` to run following a `cron` pattern or on machine startup. This is achieved via `pm2`. Tried to avoid as many problems as possible when user already have `pm2` running on its machine
- `auto-pull` scheduling robustness improvement: `auto-pull` is designed to let user only add one type of schedule and edit only the relevant ones (`cron`). It is obviously possible to delete any running scheduled task
- `auto-pull` configuration module is now printing current configuration to user if any already exists. It then prompts user to confirm any updates are required. Does not include specific setting update yet (starts the whole configuration again)
- improved logging behavior of app