### PR TITLE
Updates on key generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@
 
 This package allows users to easily manage _GitHub_ on their machines. Some features are aimed at developers while some are aiming novice users/non developers.
 
+**Examples of what can be done:**
+- commit, stage & push operation at once via interactive CLI
+- pull (for current, multiple or all branches)
+- clone a repository
+- generate an SSH key and automatically work with it inside of `git-assist`
+- generate a GPG key and automatically work with it inside of `git-assist`
+- configure user globally or for a repository
+- setup `git-assist` so that it auto-pulls from multiple repository. This can also be scheduled to run on machine startup or following a _cron_ pattern
+
 ## <img src="https://emoji.fileformat.info/gemoji/package.png" width="27px"> How to install it
 
 **NPM (developers)**

--- a/src/functions/clone/helpers/git-process/clone.js
+++ b/src/functions/clone/helpers/git-process/clone.js
@@ -39,13 +39,5 @@ async function sshClone(url) {
   await auth.sshAuth()
   // isomorphic-git doesn't seem to handle SSH cloning just yet so we use regular git command for now. Same as in push utility
   const spawnSync = require('child_process').spawnSync
-  const cloneOp = spawnSync('git', ['clone', url])
-  const stdout = cloneOp.stdout.toString().trim()
-  const stderr = cloneOp.stderr.toString().trim()
-  if (stdout.length > 0) {
-    console.log(stdout)
-  }
-  if (stderr.length > 0) {
-    console.log(stderr)
-  }
+  spawnSync('git', ['clone', url], {stdio: 'inherit'})
 }

--- a/src/functions/config/helpers/set-global-config.js
+++ b/src/functions/config/helpers/set-global-config.js
@@ -10,7 +10,7 @@ module.exports = (info) => {
   spawnSync('git', ['config', '--global', 'user.name', info.name])
   spawnSync('git', ['config', '--global', 'user.email', info.email])
   const gpgKeyMap = config.get('gpg') || {}
-  const keyId = gpgKeyMap[info.email]
+  const keyId = gpgKeyMap[info.email].id
   if (!keyId) {
     clog.error(`No GPG key was created for GitHub for ${chalk.italic.green(info.email)}: not adding a GPG key to this configuration.`)
     clog.info(`Please run ${chalk.cyan.italic('git-assist generate-gpg')} in order to generate a GPG key then rerun this command to add it automatically to your configuration.\n`)

--- a/src/functions/config/helpers/set-local-config.js
+++ b/src/functions/config/helpers/set-local-config.js
@@ -36,7 +36,7 @@ function gpgParams(info) {
     fileExtension: 'conf'
   })
   const gpgKeyMap = config.get('gpg') || {}
-  const keyId = gpgKeyMap[info.email]
+  const keyId = gpgKeyMap[info.email].id
   if (!keyId) {
     clog.error(`No GPG key was created for GitHub for ${chalk.italic.green(info.email)}: not adding a GPG key to this configuration.`)
     clog.info(`Please run ${chalk.cyan.italic('git-assist generate-gpg')} in order to generate a GPG key then rerun this command to add it automatically to your configuration.\n`)

--- a/src/functions/generate-gpg/helpers/update-config.js
+++ b/src/functions/generate-gpg/helpers/update-config.js
@@ -10,7 +10,10 @@ module.exports = (info, keyId) => {
   if (gpgKeyMap[info.email]) {
     clog.info(`A GPG key already exists for ${info.email}, this key will now be updated with the newly generated key...`)
   }
-  gpgKeyMap[info.email] = keyId
+  gpgKeyMap[info.email] = {
+    lastModified: Date.now(),
+    id: keyId
+  }
   config.set('gpg', gpgKeyMap)
   clog.success(`GPG key successfully added for ${info.email}!`)
 }

--- a/src/functions/generate-ssh/helpers/generate-ssh.js
+++ b/src/functions/generate-ssh/helpers/generate-ssh.js
@@ -50,7 +50,10 @@ function updateConfig(info) {
   if (sshKeyMap[info.email]) {
     clog.info(`An SSH key already exists for ${info.email}, this key will now be updated with the newly generated key...`)
   }
-  sshKeyMap[info.email] = info.path
+  sshKeyMap[info.email] = {
+    lastModified: Date.now(),
+    path: info.path
+  }
   config.set('ssh', sshKeyMap)
   clog.success(`SSH key successfully added for ${info.email}!`)
 }

--- a/src/functions/pull/helpers/git-process/pull.js
+++ b/src/functions/pull/helpers/git-process/pull.js
@@ -41,15 +41,7 @@ async function sshPull (branches) {
   for (const branch of branches) {
     clog.info(`Pulling from branch ${branch}`)
     spawnSync('git', ['checkout', branch])
-    const pullOp = spawnSync('git', ['pull'])
-    const stdout = pullOp.stdout.toString().trim()
-    const stderr = pullOp.stderr.toString().trim()
-    if (stdout.length > 0) {
-      console.log(stdout)
-    }
-    if (stderr.length > 0) {
-      console.log(stderr)
-    }
+    spawnSync('git', ['pull'], {stdio: 'inherit'})
     clog.success('Done!')
   }
   spawnSync('git', ['checkout', currentBranch])

--- a/src/functions/push/helpers/git-process/commit.js
+++ b/src/functions/push/helpers/git-process/commit.js
@@ -3,17 +3,9 @@ module.exports = async (message) => {
   // not using isomorphic-git here because the signing plugin has some security issues
   const spawnSync = require('child_process').spawnSync
   clog.info('If required, please input your passphrase for your GPG key in order to sign your commit.')
-  const commitOp = spawnSync('git', [
+  spawnSync('git', [
     'commit',
     '-S',
     '-m', message
-  ])
-  const stdout = commitOp.stdout.toString().trim()
-  const stderr = commitOp.stderr.toString().trim()
-  if (stdout.length > 0) {
-    console.log(stdout)
-  }
-  if (stderr.length > 0) {
-    console.log(stderr)
-  }
+  ], {stdio: 'inherit'})
 }

--- a/src/functions/push/helpers/git-process/push.js
+++ b/src/functions/push/helpers/git-process/push.js
@@ -37,13 +37,5 @@ async function sshPush() {
   await auth.sshAuth()
   // isomorphic-git is not supporting ssh yet so we use the regular bash call to git to operate over ssh
   const spawnSync = require('child_process').spawnSync
-  const pushOp = spawnSync('git' , ['push'])
-  const stdout = pushOp.stdout.toString().trim()
-  const stderr = pushOp.stderr.toString().trim()
-  if (stdout.length > 0) {
-    console.log(stdout)
-  }
-  if (stderr.length > 0) {
-    console.log(stderr)
-  }
+  spawnSync('git' , ['push'], {stdio: 'inherit'})
 }

--- a/src/functions/push/helpers/git-process/stage.js
+++ b/src/functions/push/helpers/git-process/stage.js
@@ -5,15 +5,7 @@ module.exports = async (addAll, params) => {
   } else {
     // TODO: rewrite this to work with isomorphic-git. There needs to be a way
     const spawnSync = require('child_process').spawnSync
-    const stageOp = spawnSync('git', ['add', ...params])
-    const stdout = stageOp.stdout.toString().trim()
-    const stderr = stageOp.stderr.toString().trim()
-    if (stdout.length > 0) {
-      console.log(stdout)
-    }
-    if (stderr.length > 0) {
-      console.log(stderr)
-    }
+    spawnSync('git', ['add', ...params], {stdio: 'inherit'})
   }
 }
 

--- a/src/utils/auth/auth.js
+++ b/src/utils/auth/auth.js
@@ -24,7 +24,7 @@ module.exports = {
       fileExtension: 'conf'
     })
     const sshKeyMap = config.get('ssh') || {}
-    const keyPath = sshKeyMap ? sshKeyMap[username] : undefined
+    const keyPath = sshKeyMap ? sshKeyMap[username].path : undefined
     if (!keyPath) {
       const chalk = require('chalk')
       clog.info(`No SSH key was found for ${chalk.italic.green(username)}: not proceeding to authenticate via ${chalk.italic.cyan('git-assist')}. Relying on SSH keys already added to the SSH agent instead.`)


### PR DESCRIPTION
Updated key generators:

- changed data structure in config file from simple `string` value for user email keys to being an `object` containing last modification date of the key as well as its core data (`path` or `id`)
- updated GitHub related operation to display their information in the console via `{stdio: 'inherit'} `instead of extracting their `stdout` and `stderr`
- updated docs with example of what `git-assist` can do